### PR TITLE
Fix compilation of modifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,10 +210,10 @@ clean:
 	find -name *.o | xargs ${RM}
 
 ${COMMON_SHARED_OBJECTS}:
-	${COMPILER} ${COMPILER_FLAGS} ${SHARED_COMPILER_FLAGS} -o $@ ${@:shared/%.o=%.cpp}
+	${COMPILER} ${PHP_COMPILER_FLAGS} ${SHARED_COMPILER_FLAGS} -o $@ ${@:shared/%.o=%.cpp}
 
 ${COMMON_STATIC_OBJECTS}:
-	${COMPILER} ${COMPILER_FLAGS} ${STATIC_COMPILER_FLAGS} -o $@ ${@:static/%.o=%.cpp}
+	${COMPILER} ${PHP_COMPILER_FLAGS} ${STATIC_COMPILER_FLAGS} -o $@ ${@:static/%.o=%.cpp}
 
 ${PHP_SHARED_OBJECTS}:
 	${COMPILER} ${PHP_COMPILER_FLAGS} ${SHARED_COMPILER_FLAGS} -o $@ ${@:shared/%.o=%.cpp}

--- a/common/modifiers.cpp
+++ b/common/modifiers.cpp
@@ -19,6 +19,15 @@ namespace Php {
 /**
  *  The modifiers are constants
  */
+#if PHP_VERSION_ID >= 70400
+const int Static    =   0x10;
+const int Abstract  =   0x40;
+const int Final     =   0x20;
+const int Public    =   0x01;
+const int Protected =   0x02;
+const int Private   =   0x04;
+const int Const     =   0;
+#else
 const int Static    =   0x01;
 const int Abstract  =   0x02;
 const int Final     =   0x04;
@@ -26,6 +35,7 @@ const int Public    =   0x100;
 const int Protected =   0x200;
 const int Private   =   0x400;
 const int Const     =   0;
+#endif
 
 /**
  *  Modifiers that are supported for methods and properties

--- a/common/modifiers.cpp
+++ b/common/modifiers.cpp
@@ -10,6 +10,7 @@
  *  @copyright 2014 Copernica BV
  */
 #include "includes.h"
+#include <php.h>
 
 /**
  *  Set up namespace

--- a/zend/classimpl.h
+++ b/zend/classimpl.h
@@ -13,6 +13,12 @@
  */
 namespace Php {
 
+#if PHP_VERSION_ID >= 70400
+#	define PHP_WRITE_PROP_HANDLER_TYPE zval *
+#else
+#	define PHP_WRITE_PROP_HANDLER_TYPE void
+#endif
+
 /**
  *  Class definition
  */
@@ -257,9 +263,9 @@ public:
      *  @param  name            The name of the property
      *  @param  value           The new value
      *  @param  cache_slot      The cache slot used
-     *  @return zval
+     *  @return zval*
      */
-    static void writeProperty(zval *object, zval *name, zval *value, void **cache_slot);
+    static PHP_WRITE_PROP_HANDLER_TYPE writeProperty(zval *object, zval *name, zval *value, void **cache_slot);
 
     /**
      *  Function that is called to check whether a certain property is set

--- a/zend/value.cpp
+++ b/zend/value.cpp
@@ -1499,9 +1499,12 @@ bool Value::contains(const char *key, int size) const
     }
     else if (isObject())
     {
+#if PHP_VERSION_ID >= 70400
         // retrieve the object pointer and check whether the property we are trying to retrieve
+        if (zend_check_property_access(Z_OBJ_P(_val), String(key, size), 0) == FAILURE) return false;
+#else
         if (zend_check_property_access(Z_OBJ_P(_val), String(key, size)) == FAILURE) return false;
-
+#endif
         // check if the 'has_property' method is available for this object
         auto *has_property = Z_OBJ_HT_P(_val)->has_property;
 


### PR DESCRIPTION
The visibility modifiers for PHP 7.4 weren't applied because the PHP_VERSION_ID constant wasn't defined for files in the common target.
This PR fixes the issue by using appropriate include flags and including the php header files.