### PR TITLE
Fix get_closure function signature for php74

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - nightly # doesn't work yet on PHP 7.4! not building.
+  - 7.4
+  - 8.0
+  - nightly 
 
 
 # setting the env is the easiest, because it will mix with all the separate php versions (travis does this)

--- a/zend/callable.cpp
+++ b/zend/callable.cpp
@@ -36,9 +36,12 @@ void Callable::invoke(INTERNAL_FUNCTION_PARAMETERS)
 #else
     // Sanity check
     assert(info[argc].type != 0 && info[argc].name == nullptr);
-
     // the callable we are retrieving
+#if PHP_VERSION_ID < 80000
     Callable *callable = reinterpret_cast<Callable*>(info[argc].type);
+#else
+    Callable *callable = reinterpret_cast<Callable*>(info[argc].type.ptr);
+#endif
 #endif
 
     // check if sufficient parameters were passed (for some reason this check
@@ -99,10 +102,10 @@ void Callable::initialize(zend_function_entry *entry, const char *classname, int
         _argv[_argc + 1].class_name = reinterpret_cast<const char*>(this);
 #else
         // @todo    this is broken. the zend engine, from 7.2 onwards copies over
-        //          the struct and slices of the last element, because the num_args
+        //          the struct and slices off the last element, because the num_args
         //          is incorrect in their view. another place to put this may be
         //          hiding it behind the fname
-        _argv[_argc + 1].type = reinterpret_cast<zend_type>(this);
+       // _argv[_argc + 1].type = reinterpret_cast<zend_type>(this);
 #endif
 
         // we use our own invoke method, which does a lookup
@@ -129,8 +132,10 @@ void Callable::initialize(zend_internal_function_info *info, const char *classna
 {
     // initialize all common elements
     info->required_num_args = _required;
+#if PHP_VERSION_ID < 80000
     info->return_reference = false;
     info->_is_variadic = false;
+#endif
 
     // the structure has been slightly altered since php7.2
 #if PHP_VERSION_ID < 70200
@@ -147,9 +152,18 @@ void Callable::initialize(zend_internal_function_info *info, const char *classna
 #else
     // the properties that are available on php 7.2 and higher
     info->required_num_args = _required;
+#if PHP_VERSION_ID < 80000
     info->return_reference = false;
     info->_is_variadic = false;
     info->type = ZEND_TYPE_ENCODE((int)_return, true);
+#else
+    if ((int)_return) {
+        info->type = (zend_type)ZEND_TYPE_INIT_CODE((int)_return, true, 0);
+    } else {
+        info->type = (zend_type)ZEND_TYPE_INIT_NONE(0);
+    }
+
+#endif
 #endif
 }
 

--- a/zend/callable.h
+++ b/zend/callable.h
@@ -53,13 +53,14 @@ public:
 
         // initialize all elements to null
         _argv[i].name = nullptr;
+#if PHP_VERSION_ID < 80000
         _argv[i].is_variadic = false;
         _argv[i].pass_by_reference = false;
-
+#endif
         // initialize the extra argument prior to 7.2
 #if PHP_VERSION_ID < 70200
         _argv[i].class_name = nullptr;
-#else
+#elif PHP_VERSION_ID < 80000
         _argv[i].type = 0;
 #endif
     }
@@ -203,6 +204,26 @@ protected:
             case Type::Object:      info->type_hint = IS_OBJECT;    break;  // must be an object of the given classname
             case Type::Callable:    info->type_hint = IS_CALLABLE;  break;  // anything that can be invoked
             default:                info->type_hint = IS_UNDEF;     break;  // if not specified we allow anything
+#elif PHP_VERSION_ID >= 80000
+            case Type::Undefined:   info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_UNDEF, arg.allowNull(), 0);     break;  // undefined means we'll accept any type
+            case Type::Null:        info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_UNDEF, arg.allowNull(), 0);     break;  // this is likely an error, what good would accepting NULL be? accept anything
+            case Type::False:       info->type = (zend_type) ZEND_TYPE_INIT_CODE(_IS_BOOL, arg.allowNull(), 0);     break;  // accept true as well ;)
+            case Type::True:        info->type = (zend_type) ZEND_TYPE_INIT_CODE(_IS_BOOL, arg.allowNull(), 0);     break;  // accept false as well
+            case Type::Bool:        info->type = (zend_type) ZEND_TYPE_INIT_CODE(_IS_BOOL, arg.allowNull(), 0);     break;  // any bool will do, true, false, the options are limitless
+            case Type::Numeric:     info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, arg.allowNull(), 0);      break;  // accept integers here
+            case Type::Float:       info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_DOUBLE, arg.allowNull(), 0);    break;  // floating-point values welcome too
+            case Type::String:      info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_STRING, arg.allowNull(), 0);    break;  // accept strings, should auto-cast objects with __toString as well
+            case Type::Array:       info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_ARRAY, arg.allowNull(), 0);     break;  // array of anything (individual members cannot be restricted)
+            case Type::Object:
+                if (arg.classname()) {
+                    info->type = (zend_type) ZEND_TYPE_INIT_CLASS(arg.encoded(), arg.allowNull(), 0);
+                    break;
+                }
+                info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_OBJECT, arg.allowNull(), 0);
+                break;
+            case Type::Callable:    info->type = (zend_type) ZEND_TYPE_INIT_CODE(IS_CALLABLE, arg.allowNull(), 0);  break;  // anything that can be invoke
+
+           default:                info->type = ZEND_TYPE_INIT_CODE(IS_UNDEF, 0, 0);     break;  // if not specified we allow anything
 #else
             case Type::Undefined:   info->type = ZEND_TYPE_ENCODE(IS_UNDEF, arg.allowNull());     break;  // undefined means we'll accept any type
             case Type::Null:        info->type = ZEND_TYPE_ENCODE(IS_UNDEF, arg.allowNull());     break;  // this is likely an error, what good would accepting NULL be? accept anything
@@ -221,7 +242,7 @@ protected:
             default:                info->type = ZEND_TYPE_ENCODE(IS_UNDEF, arg.allowNull());     break;  // if not specified we allow anything
 #endif
         }
-
+#if PHP_VERSION_ID < 80000
         // from PHP 5.6 and onwards, an is_variadic property can be set, this
         // specifies whether this argument is the first argument that specifies
         // the type for a variable length list of arguments. For now we only
@@ -230,6 +251,7 @@ protected:
 
         // whether or not to pass the argument by reference
         info->pass_by_reference = arg.byReference();
+#endif
     }
 
     /**

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -285,7 +285,11 @@ zend_function *ClassImpl::getStaticMethod(zend_class_entry *entry, zend_string *
  *  @param  object_ptr
  *  @return int
  */
+#if PHP_VERSION_ID < 80000
+int ClassImpl::getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry_ptr, zend_function **func, zend_object **object_ptr)
+#else
 int ClassImpl::getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry_ptr, zend_function **func, zend_object **object_ptr, zend_bool check_only)
+#endif
 {
     // it is really unbelievable how the Zend engine manages to implement every feature
     // in a complete different manner. You would expect the __invoke() and the

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -285,7 +285,7 @@ zend_function *ClassImpl::getStaticMethod(zend_class_entry *entry, zend_string *
  *  @param  object_ptr
  *  @return int
  */
-int ClassImpl::getClosure(zval *object, zend_class_entry **entry_ptr, zend_function **func, zend_object **object_ptr)
+int ClassImpl::getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry_ptr, zend_function **func, zend_object **object_ptr, zend_bool check_only)
 {
     // it is really unbelievable how the Zend engine manages to implement every feature
     // in a complete different manner. You would expect the __invoke() and the
@@ -315,7 +315,11 @@ int ClassImpl::getClosure(zval *object, zend_class_entry **entry_ptr, zend_funct
 
     // store pointer to ourselves (note that the entry_ptr is useless
     // inside this function as it is always uninitialized for some reason)
+#if PHP_VERSION_ID < 80000
     data->self = self(Z_OBJCE_P(object));
+#else
+    data->self = self(object->ce);
+#endif
 
     // assign this dynamically allocated variable to the func parameter
     // the cast is ok, because zend_internal_function is a member of the
@@ -324,7 +328,11 @@ int ClassImpl::getClosure(zval *object, zend_class_entry **entry_ptr, zend_funct
 
     // the object_ptr should be filled with the object on which the method is
     // called (otherwise the Zend engine tries to call the method statically)
+#if PHP_VERSION_ID < 80000
     *object_ptr = Z_OBJ_P(object);
+#else
+    *object_ptr = object;
+#endif
 
     // done
     return SUCCESS;
@@ -373,7 +381,11 @@ zend_object_handlers *ClassImpl::objectHandlers()
     _handlers.cast_object = &ClassImpl::cast;
 
     // method to compare two objects
+#if PHP_VERSION_ID < 80000
     _handlers.compare_objects = &ClassImpl::compare;
+#else
+    _handlers.compare = &ClassImpl::compare;
+#endif
 
     // set the offset between our class implementation and
     // the zend_object member in the allocated structure
@@ -426,10 +438,17 @@ int ClassImpl::compare(zval *val1, zval *val2)
     catch (const NotImplemented &exception)
     {
         // it was not implemented, do we have a default?
+#if PHP_VERSION_ID < 80000
         if (!std_object_handlers.compare_objects) return 1;
 
         // call default
         return std_object_handlers.compare_objects(val1, val2);
+#else
+        if (!std_object_handlers.compare) return 1;
+
+        // call default
+        return std_object_handlers.compare(val1, val2);
+#endif
     }
     catch (Throwable &throwable)
     {
@@ -448,14 +467,17 @@ int ClassImpl::compare(zval *val1, zval *val2)
  *  @param  type
  *  @return int
  */
-int ClassImpl::cast(zval *val, zval *retval, int type)
+int ClassImpl::cast(ZEND_OBJECT_OR_ZVAL val, zval *retval, int type)
 {
     // get the base c++ object
     Base *object = ObjectImpl::find(val)->object();
 
     // retrieve the class entry linked to this object
+#if PHP_VERSION_ID < 80000
     auto *entry = Z_OBJCE_P(val);
-
+#else
+    auto *entry = val->ce;
+#endif
     // we need the C++ class meta-information object
     ClassBase *meta = self(entry)->_base;
 
@@ -508,11 +530,14 @@ int ClassImpl::cast(zval *val, zval *retval, int type)
  *  @param  val             The object to be cloned
  *  @return zend_object     The object to be created
  */
-zend_object *ClassImpl::cloneObject(zval *val)
+zend_object *ClassImpl::cloneObject(ZEND_OBJECT_OR_ZVAL val)
 {
     // retrieve the class entry linked to this object
+#if PHP_VERSION_ID < 80000
     auto *entry = Z_OBJCE_P(val);
-
+#else
+    auto *entry = val->ce;
+#endif
     // we need the C++ class meta-information object
     ClassImpl *impl = self(entry);
     ClassBase *meta = impl->_base;
@@ -554,7 +579,7 @@ zend_object *ClassImpl::cloneObject(zval *val)
  *  @param  count
  *  @return int
  */
-int ClassImpl::countElements(zval *object, zend_long *count)
+int ClassImpl::countElements(ZEND_OBJECT_OR_ZVAL object, zend_long *count)
 {
     // does it implement the countable interface?
     Countable *countable = dynamic_cast<Countable*>(ObjectImpl::find(object)->object());
@@ -602,7 +627,7 @@ int ClassImpl::countElements(zval *object, zend_long *count)
  *  @param  rv              Pointer to where to store the data
  *  @return zval
  */
-zval *ClassImpl::readDimension(zval *object, zval *offset, int type, zval *rv)
+zval *ClassImpl::readDimension(ZEND_OBJECT_OR_ZVAL object, zval *offset, int type, zval *rv)
 {
     // what to do with the type?
     //
@@ -664,7 +689,7 @@ zval *ClassImpl::readDimension(zval *object, zval *offset, int type, zval *rv)
  *  @param  value           The new value
  *  @return zval
  */
-void ClassImpl::writeDimension(zval *object, zval *offset, zval *value)
+void ClassImpl::writeDimension(ZEND_OBJECT_OR_ZVAL object, zval *offset, zval *value)
 {
     // does it implement the arrayaccess interface?
     ArrayAccess *arrayaccess = dynamic_cast<ArrayAccess*>(ObjectImpl::find(object)->object());
@@ -705,7 +730,7 @@ void ClassImpl::writeDimension(zval *object, zval *offset, zval *value)
  *  @param  check_empty     Was this an isset() call, or an empty() call?
  *  @return bool
  */
-int ClassImpl::hasDimension(zval *object, zval *member, int check_empty)
+int ClassImpl::hasDimension(ZEND_OBJECT_OR_ZVAL object, zval *member, int check_empty)
 {
     // does it implement the arrayaccess interface?
     ArrayAccess *arrayaccess = dynamic_cast<ArrayAccess*>(ObjectImpl::find(object)->object());
@@ -754,7 +779,7 @@ int ClassImpl::hasDimension(zval *object, zval *member, int check_empty)
  *  @param  object          The object on which it is called
  *  @param  member          The member to remove
  */
-void ClassImpl::unsetDimension(zval *object, zval *member)
+void ClassImpl::unsetDimension(ZEND_OBJECT_OR_ZVAL object, zval *member)
 {
     // does it implement the arrayaccess interface?
     ArrayAccess *arrayaccess = dynamic_cast<ArrayAccess*>(ObjectImpl::find(object)->object());
@@ -835,7 +860,7 @@ zval *ClassImpl::toZval(Value &&value, int type, zval *rv)
  *  @param  rv              Pointer to where to store the data
  *  @return val
  */
-zval *ClassImpl::readProperty(zval *object, zval *name, int type, void **cache_slot, zval *rv)
+zval *ClassImpl::readProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL name, int type, void **cache_slot, zval *rv)
 {
     // what to do with the type?
     //
@@ -858,7 +883,11 @@ zval *ClassImpl::readProperty(zval *object, zval *name, int type, void **cache_s
     Base *base = ObjectImpl::find(object)->object();
 
     // retrieve the class entry linked to this object
+#if PHP_VERSION_ID < 80000
     auto *entry = Z_OBJCE_P(object);
+#else
+    auto *entry = object->ce;
+#endif
 
     // we need the C++ class meta-information object
     ClassImpl *impl = self(entry);
@@ -916,13 +945,17 @@ zval *ClassImpl::readProperty(zval *object, zval *name, int type, void **cache_s
  *  @param  cache_slot      The cache slot used
  *  @return zval
  */
-PHP_WRITE_PROP_HANDLER_TYPE ClassImpl::writeProperty(zval *object, zval *name, zval *value, void **cache_slot)
+PHP_WRITE_PROP_HANDLER_TYPE ClassImpl::writeProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL name, zval *value, void **cache_slot)
 {
     // retrieve the object and class
     Base *base = ObjectImpl::find(object)->object();
 
     // retrieve the class entry linked to this object
+#if PHP_VERSION_ID < 80000
     auto *entry = Z_OBJCE_P(object);
+#else
+    auto *entry = object->ce;
+#endif
 
     // we need the C++ class meta-information object
     ClassImpl *impl = self(entry);
@@ -1007,7 +1040,7 @@ PHP_WRITE_PROP_HANDLER_TYPE ClassImpl::writeProperty(zval *object, zval *name, z
  *  @param  cache_slot      The cache slot used
  *  @return bool
  */
-int ClassImpl::hasProperty(zval *object, zval *name, int has_set_exists, void **cache_slot)
+int ClassImpl::hasProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL name, int has_set_exists, void **cache_slot)
 {
     // the default implementation throws an exception, if we catch that
     // we know for sure that the user has not overridden the __isset method
@@ -1017,7 +1050,11 @@ int ClassImpl::hasProperty(zval *object, zval *name, int has_set_exists, void **
         Base *base = ObjectImpl::find(object)->object();
 
         // retrieve the class entry linked to this object
+#if PHP_VERSION_ID < 80000
         auto *entry = Z_OBJCE_P(object);
+#else
+        auto *entry = object->ce;
+#endif
 
         // we need the C++ class meta-information object
         ClassImpl *impl = self(entry);
@@ -1071,15 +1108,18 @@ int ClassImpl::hasProperty(zval *object, zval *name, int has_set_exists, void **
  *  @param  member          The member to remove
  *  @param  cache_slot      The cache slot used
  */
-void ClassImpl::unsetProperty(zval *object, zval *member, void **cache_slot)
+void ClassImpl::unsetProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL member, void **cache_slot)
 {
     // the default implementation throws an exception, if we catch that
     // we know for sure that the user has not overridden the __unset method
     try
     {
         // retrieve the class entry linked to this object
+#if PHP_VERSION_ID < 80000
         auto *entry = Z_OBJCE_P(object);
-
+#else
+        auto *entry = object->ce;
+#endif
         // we need the C++ class meta-information object
         ClassImpl *impl = self(entry);
 

--- a/zend/classimpl.h
+++ b/zend/classimpl.h
@@ -328,7 +328,11 @@ public:
      *  @param  object_ptr  To be filled with the object on which the method is to be called
      *  @return int
      */
+#if PHP_VERSION_ID < 80000
+    static int getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry, zend_function **func, zend_object **object_ptr);
+#else
     static int getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry, zend_function **func, zend_object **object_ptr, zend_bool check_only);
+#endif
 
     /**
      *  Function to cast the object to a different type

--- a/zend/classimpl.h
+++ b/zend/classimpl.h
@@ -18,7 +18,13 @@ namespace Php {
 #else
 #	define PHP_WRITE_PROP_HANDLER_TYPE void
 #endif
-
+#if PHP_VERSION_ID < 80000
+#define ZEND_OBJECT_OR_ZVAL zval *
+#define ZEND_STRING_OR_ZVAL zval *
+#else
+#define ZEND_OBJECT_OR_ZVAL zend_object *
+#define ZEND_STRING_OR_ZVAL zend_string *
+#endif
 /**
  *  Class definition
  */
@@ -189,7 +195,7 @@ public:
      *  @return zend_object             Object info
      */
     static zend_object *createObject(zend_class_entry *entry);
-    static zend_object *cloneObject(zval *val);
+    static zend_object *cloneObject(ZEND_OBJECT_OR_ZVAL val);
     static void destructObject(zend_object *object);
     static void freeObject(zend_object *object);
 
@@ -212,7 +218,7 @@ public:
      *  @param  count
      *  @return int
      */
-    static int countElements(zval *object, zend_long *count);
+    static int countElements(ZEND_OBJECT_OR_ZVAL object, zend_long *count);
 
     /**
      *  Function that is called when the object is used as an array in PHP
@@ -224,10 +230,10 @@ public:
      *  @param  check_empty     ????
      *  @return zval
      */
-    static zval *readDimension(zval *object, zval *offset, int type, zval *rv);
-    static void writeDimension(zval *object, zval *offset, zval *value);
-    static int  hasDimension(zval *object, zval *offset, int check_empty);
-    static void unsetDimension(zval *object, zval *offset);
+    static zval *readDimension(ZEND_OBJECT_OR_ZVAL object, zval *offset, int type, zval *rv);
+    static void writeDimension(ZEND_OBJECT_OR_ZVAL object, zval *offset, zval *value);
+    static int  hasDimension(ZEND_OBJECT_OR_ZVAL object, zval *offset, int check_empty);
+    static void unsetDimension(ZEND_OBJECT_OR_ZVAL object, zval *offset);
 
     /**
      *  Retrieve pointer to our own object handlers
@@ -261,7 +267,7 @@ public:
      *  @param  rv              Pointer to where to store the data
      *  @return zval
      */
-    static zval *readProperty(zval *object, zval *name, int type, void **cache_slot, zval *rv);
+    static zval *readProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL name, int type, void **cache_slot, zval *rv);
 
     /**
      *  Function that is called when a property is set / updated
@@ -272,7 +278,7 @@ public:
      *  @param  cache_slot      The cache slot used
      *  @return zval*
      */
-    static PHP_WRITE_PROP_HANDLER_TYPE writeProperty(zval *object, zval *name, zval *value, void **cache_slot);
+    static PHP_WRITE_PROP_HANDLER_TYPE writeProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL name, zval *value, void **cache_slot);
 
     /**
      *  Function that is called to check whether a certain property is set
@@ -283,7 +289,7 @@ public:
      *  @param  cache_slot      The cache slot used
      *  @return bool
      */
-    static int hasProperty(zval *object, zval *name, int has_set_exists, void **cache_slot);
+    static int hasProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL name, int has_set_exists, void **cache_slot);
 
     /**
      *  Function that is called when a property is removed from the project
@@ -292,7 +298,7 @@ public:
      *  @param  member          The member to remove
      *  @param  cache_slot      The cache slot used
      */
-    static void unsetProperty(zval *object, zval *member, void **cache_slot);
+    static void unsetProperty(ZEND_OBJECT_OR_ZVAL object, ZEND_STRING_OR_ZVAL member, void **cache_slot);
 
     /**
      *  Method that returns information about the function signature of a undefined method
@@ -322,7 +328,7 @@ public:
      *  @param  object_ptr  To be filled with the object on which the method is to be called
      *  @return int
      */
-    static int getClosure(zval *object, zend_class_entry **entry, zend_function **func, zend_object **object_ptr);
+    static int getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry, zend_function **func, zend_object **object_ptr, zend_bool check_only);
 
     /**
      *  Function to cast the object to a different type
@@ -331,7 +337,7 @@ public:
      *  @param  type
      *  @return int
      */
-    static int cast(zval *object, zval *retval, int type);
+    static int cast(ZEND_OBJECT_OR_ZVAL object, zval *retval, int type);
 
     /**
      *  Function to compare two objects

--- a/zend/extensionimpl.cpp
+++ b/zend/extensionimpl.cpp
@@ -107,7 +107,11 @@ static ExtensionImpl *find(int number)
  *  @param  number      Module number
  *  @return int         0 on success
  */
+#if PHP_VERSION_ID < 80000
 int ExtensionImpl::processStartup(int type, int module_number)
+#else
+zend_result ExtensionImpl::processStartup(int type, int module_number)
+#endif
 {
     // initialize and allocate the "global" variables
     ZEND_INIT_MODULE_GLOBALS(phpcpp, init_globals, NULL); 
@@ -116,7 +120,7 @@ int ExtensionImpl::processStartup(int type, int module_number)
     auto *extension = find(module_number);
 
     // initialize the extension
-    return BOOL2SUCCESS(extension->initialize(module_number));
+    return extension->initialize(module_number) ? SUCCESS : FAILURE;
 }
 
 /**
@@ -125,7 +129,7 @@ int ExtensionImpl::processStartup(int type, int module_number)
  *  @param  number      Module number
  *  @return int
  */
-int ExtensionImpl::processShutdown(int type, int module_number)
+ZEND_RESULT_OR_INT ExtensionImpl::processShutdown(int type, int module_number)
 {
     // get the extension
     auto *extension = find(module_number);
@@ -134,7 +138,7 @@ int ExtensionImpl::processShutdown(int type, int module_number)
     number2extension.erase(module_number);
 
     // done
-    return BOOL2SUCCESS(extension->shutdown(module_number));
+    return extension->shutdown(module_number) ? SUCCESS:FAILURE;
 }
 
 /**
@@ -143,7 +147,7 @@ int ExtensionImpl::processShutdown(int type, int module_number)
  *  @param  number      Module number
  *  @return int         0 on success
  */
-int ExtensionImpl::processRequest(int type, int module_number)
+ZEND_RESULT_OR_INT ExtensionImpl::processRequest(int type, int module_number)
 {
     // get the extension
     auto *extension = find(module_number);
@@ -152,7 +156,7 @@ int ExtensionImpl::processRequest(int type, int module_number)
     if (extension->_onRequest) extension->_onRequest();
     
     // done
-    return BOOL2SUCCESS(true);
+    return SUCCESS;
 }
 
 /**
@@ -161,7 +165,7 @@ int ExtensionImpl::processRequest(int type, int module_number)
  *  @param  number      Module number
  *  @return int         0 on success
  */
-int ExtensionImpl::processIdle(int type, int module_number)
+ZEND_RESULT_OR_INT ExtensionImpl::processIdle(int type, int module_number)
 {
     // get the extension
     auto *extension = find(module_number);
@@ -170,7 +174,7 @@ int ExtensionImpl::processIdle(int type, int module_number)
     if (extension->_onIdle) extension->_onIdle();
     
     // done
-    return BOOL2SUCCESS(true);
+    return SUCCESS;
 }
 
 /**
@@ -180,7 +184,7 @@ int ExtensionImpl::processIdle(int type, int module_number)
  *  @param  number      Module number
  *  @return int         0 on success
  */
-int ExtensionImpl::processMismatch(int type, int module_number)
+ZEND_RESULT_OR_INT ExtensionImpl::processMismatch(int type, int module_number)
 {
     // get the extension
     auto *extension = find(module_number);
@@ -189,7 +193,7 @@ int ExtensionImpl::processMismatch(int type, int module_number)
     warning << "Version mismatch between PHP-CPP and extension " << extension->name() << " " << extension->version() << " (recompile needed?)" << std::endl;
     
     // done
-    return BOOL2SUCCESS(true);
+    return SUCCESS;
 }
 
 /**

--- a/zend/extensionimpl.h
+++ b/zend/extensionimpl.h
@@ -12,6 +12,12 @@
  */
 namespace Php {
 
+#if PHP_VERSION_ID < 80000
+#define ZEND_RESULT_OR_INT int
+#else
+#define ZEND_RESULT_OR_INT zend_result
+#endif
+
 /**
  *  Class definition
  */
@@ -157,23 +163,23 @@ private:
      *  @param  number      Module number
      *  @return int         0 on success
      */
-    static int processStartup(int type, int module_number);
-    
+    static ZEND_RESULT_OR_INT processStartup(int type, int module_number);
+
     /**
      *  Function that is called when the extension is about to be stopped
      *  @param  type        Module type
      *  @param  number      Module number
      *  @return int
      */
-    static int processShutdown(int type, int module_number);
-    
+    static ZEND_RESULT_OR_INT processShutdown(int type, int module_number);
+
     /**
      *  Function that is called when a request starts
      *  @param  type        Module type
      *  @param  number      Module number
      *  @return int         0 on success
      */
-    static int processRequest(int type, int module_number);
+    static ZEND_RESULT_OR_INT processRequest(int type, int module_number);
 
     /**
      *  Function that is called when a request is ended
@@ -181,7 +187,7 @@ private:
      *  @param  number      Module number
      *  @return int         0 on success
      */
-    static int processIdle(int type, int module_number);
+    static ZEND_RESULT_OR_INT processIdle(int type, int module_number);
 
     /**
      *  Function that is called when the PHP engine initializes with a different PHP-CPP
@@ -190,7 +196,7 @@ private:
      *  @param  number      Module number
      *  @return int         0 on success
      */
-    static int processMismatch(int type, int module_number);
+    static ZEND_RESULT_OR_INT processMismatch(int type, int module_number);
 };
 
 /**

--- a/zend/script.cpp
+++ b/zend/script.cpp
@@ -37,7 +37,11 @@ zend_op_array *Script::compile(const char *name, const char *phpcode, size_t siz
     CompilerOptions options(ZEND_COMPILE_DEFAULT_FOR_EVAL);
     
     // compile the string
+#if PHP_VERSION_ID < 80000
     return zend_compile_string(source._val, (char *)name);
+#else
+    return zend_compile_string(zval_get_string(source._val), (char*)name);
+#endif
 }
 
 /**

--- a/zend/throwable.cpp
+++ b/zend/throwable.cpp
@@ -30,8 +30,12 @@ static std::string convert(zend_object *object)
     ZVAL_OBJ(&properties, object);
 
     // retrieve the message, filename, error code and line number
+#if PHP_VERSION_ID < 80000
     auto message = zval_get_string(zend_read_property(Z_OBJCE(properties), &properties, ZEND_STRL("message"), 1, &tmp));
-    
+#else
+    auto message = zval_get_string(zend_read_property(Z_OBJCE(properties), object, ZEND_STRL("message"), 1, &tmp));
+#endif
+
     // copy message to a string
     std::string result(ZSTR_VAL(message), ZSTR_LEN(message));
 
@@ -55,7 +59,11 @@ Throwable::Throwable(zend_object *object) : std::runtime_error(convert(object))
     ZVAL_OBJ(&properties, object);
 
     // retrieve the error code
+#if PHP_VERSION_ID < 80000
     _code = zval_get_long(zend_read_property(Z_OBJCE(properties), &properties, ZEND_STRL("code"), 1, &result));
+#else
+    _code = zval_get_long(zend_read_property(Z_OBJCE(properties), object, ZEND_STRL("code"), 1, &result));
+#endif
 }
 
 /**

--- a/zend/value.cpp
+++ b/zend/value.cpp
@@ -392,12 +392,14 @@ Value& Value::operator=(struct _zval_struct* value)
     // If the destination is refcounted
     if (Z_REFCOUNTED_P(to))
     {
+#if PHP_VERSION_ID < 80000
         // objects can have their own assignment handler
         if (Z_TYPE_P(to) == IS_OBJECT && Z_OBJ_HANDLER_P(to, set))
         {
             Z_OBJ_HANDLER_P(to, set)(to, value);
             return *this;
         }
+#endif
 
         // If to and from are the same, there is nothing left to do
         if (to == value) return *this;
@@ -767,7 +769,11 @@ static Value do_exec(const zval *object, zval *method, int argc, zval *argv)
     // call the function
     // we're casting the const away here, object is only const so we can call this method
     // from const methods after all..
+#if PHP_VERSION_ID < 80000
     if (call_user_function_ex(CG(function_table), (zval*) object, method, &retval, argc, argv, 1, nullptr) != SUCCESS)
+#else
+    if (call_user_function(CG(function_table), (zval*) object, method, &retval, argc, argv) != SUCCESS)
+#endif
     {
         // throw an exception, the function does not exist
         throw Error("Invalid call to "+Value(method).stringValue());
@@ -1353,9 +1359,13 @@ int Value::size() const
 
         // create a variable to hold the result
         zend_long result;
-
+#if PHP_VERSION_ID < 80000
         // call the function
         return Z_OBJ_HT_P(_val)->count_elements(_val, &result) == SUCCESS ? result : 0;
+#else
+        zend_object *zobj = Z_OBJ_P(_val);
+        return Z_OBJ_HT_P(_val)->count_elements(zobj, &result) == SUCCESS ? result : 0;
+#endif
     }
 
     // not an array, return string size if this is a string
@@ -1511,12 +1521,22 @@ bool Value::contains(const char *key, int size) const
         // leap out if no 'has_property' function is not set (which should normally not occur)
         if (!has_property) return false;
 
+#if PHP_VERSION_ID < 80000
         // the property must be a zval, turn the key into a value
         Value property(key, size);
 
         // call the has_property() method (0 means: check whether property exists and is not NULL,
         // this is not really what we want, but the closest to the possible values of that parameter)
         return has_property(_val, property._val, 0, nullptr);
+#else
+        int retval = 0;
+        zend_string *tmp_str;
+        tmp_str = zend_string_init(key, size, 0);
+        retval = has_property(Z_OBJ_P(_val), tmp_str, 0, nullptr);
+        zend_string_release(tmp_str);
+        return retval;
+#endif
+
     }
     else
     {
@@ -1587,8 +1607,13 @@ Value Value::get(const char *key, int size) const
         zend_class_entry* scope = EG(fake_scope) ? EG(fake_scope) : zend_get_executed_scope();
 #endif
         // read the property
+#if PHP_VERSION_ID < 80000
         zval *property = zend_read_property(scope, _val, key, size, 0, &rv);
+#else
+        zend_object *zobj = Z_OBJ_P(_val); 
+        zval *property = zend_read_property(scope, zobj, key, size, 0, &rv);
 
+#endif
         // wrap in value
         return Value(property);
     }
@@ -1661,7 +1686,12 @@ void Value::setRaw(const char *key, int size, const Value &value)
 #else
         zend_class_entry* scope = EG(fake_scope) ? EG(fake_scope) : zend_get_executed_scope();
 #endif
+#if PHP_VERSION_ID < 80000
         zend_update_property(scope, _val, key, size, value._val);
+#else
+        zend_update_property(scope, Z_OBJ_P(_val), key, size, value._val);
+#endif
+
     }
     else
     {


### PR DESCRIPTION
Only php80 accepts the added parameter. Added a version check to avoid the additional parameter on php74.

>  i. get_closure() object handlers now accept an additional zend_bool parameter
     `check_only`. If it is true, the handler is called to check whether the
     object is callable; in this case the handler should not throw an exception.

Reference: https://github.com/php/php-src/blob/php-8.0.0/UPGRADING.INTERNALS